### PR TITLE
Mf 03 legal changes

### DIFF
--- a/contracts/DataFeed.sol
+++ b/contracts/DataFeed.sol
@@ -17,9 +17,8 @@ contract DataFeed is usingOraclize, DestructibleModified {
   using JsmnSolLib for string;
 
   // Global variables
-  string  public name;                   // To differentiate in case there are multiple feeds
-  bool    public useOraclize;            // True: use Oraclize (on testnet).  False: use testRPC address.
-  uint    public value;                  // API value
+  bool    public useOraclize;            // True: use Oraclize.  False: use testRPC address.
+  uint    public value;                  // Total portfolio value in USD
   uint    public usdEth;                 // USD/ETH exchange rate
   uint    public timestamp;              // Timestamp of last update
 
@@ -39,7 +38,6 @@ contract DataFeed is usingOraclize, DestructibleModified {
   event LogDataFeedError(string rawResult);
 
   function DataFeed(
-    string  _name,
     bool    _useOraclize,
     string  _queryUrl,
     uint    _secondsBetweenQueries,
@@ -49,7 +47,6 @@ contract DataFeed is usingOraclize, DestructibleModified {
     payable
   {
     // Constants
-    name = _name;
     useOraclize = _useOraclize;
     queryUrl = _queryUrl;
     secondsBetweenQueries = _secondsBetweenQueries;

--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -5,7 +5,6 @@ import "./InvestorActions.sol";
 import "./DataFeed.sol";
 import "./math/SafeMath.sol";
 import "./zeppelin/DestructiblePausable.sol";
-import './zeppelin/ERC20.sol';
 
 /**
  * @title Fund
@@ -150,7 +149,7 @@ contract Fund is DestructiblePausable {
     investors[manager].ethTotalAllocation = managerInvestment;
     investors[manager].sharesOwned = totalSupply;
     LogAllocationModification(manager, managerInvestment);
-    LogSubscription(manager, uint totalSupply, navPerShare, _managerUsdEthBasis);
+    LogSubscription(manager, totalSupply, navPerShare, _managerUsdEthBasis);
     LogTransferToExchange(managerInvestment);
 
     // Send any funds in  to exchange address
@@ -482,7 +481,7 @@ contract Fund is DestructiblePausable {
     onlyOwner
     returns (bool success)
   {
-    uint ethWithdrawal = usdToEth(accumulatedMgmtFees);
+    uint ethWithdrawal = usdToEth(accumulatedAdminFees);
     require(ethWithdrawal <= getBalance());
 
     address payee = msg.sender;

--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -68,7 +68,7 @@ contract Fund is ERC20, DestructiblePausable {
 
   // Events
   event LogAllocationModification(address indexed investor, uint eth);
-  event LogSubscriptionRequest(address indexed investor, uint eth);
+  event LogSubscriptionRequest(address indexed investor, uint eth, uint usdEthBasis);
   event LogSubscriptionCancellation(address indexed investor);
   event LogSubscription(address indexed investor, uint shares, uint navPerShare, uint usdEthExchangeRate);
   event LogRedemptionRequest(address indexed investor, uint shares);
@@ -205,15 +205,14 @@ contract Fund is ERC20, DestructiblePausable {
     return investorActions.getAvailableAllocation(_addr);
   }
 
-  // Fallback function which calls the requestSubscription function.
+  // Non-payable fallback function so that any attempt to send ETH directly to the contract is thrown
   function ()
     whenNotPaused
-    payable
-  { requestSubscription(); }
+  { }
 
   // [INVESTOR METHOD] Issue a subscription request by transferring ether into the fund
   // Delegates logic to the InvestorActions module
-  function requestSubscription()
+  function requestSubscription(uint usdEthBasis)
     whenNotPaused
     payable
     returns (bool success)
@@ -222,7 +221,7 @@ contract Fund is ERC20, DestructiblePausable {
     investors[msg.sender].ethPendingSubscription = _ethPendingSubscription;
     totalEthPendingSubscription = _totalEthPendingSubscription;
 
-    LogSubscriptionRequest(msg.sender, msg.value);
+    LogSubscriptionRequest(msg.sender, msg.value, usdEthBasis);
     return true;
   }
 

--- a/contracts/InvestorActions.sol
+++ b/contracts/InvestorActions.sol
@@ -261,7 +261,7 @@ contract InvestorActions is DestructibleModified {
     constant
     returns (uint shares)
   {
-    return ethToUsd(_eth).mul(10000).div(fund.navPerShare());
+    return ethToUsd(_eth).mul(10 ** fund.decimals()).div(fund.navPerShare());
   }
 
   // Converts shares to a corresponding amount of ether based on the current nav per share
@@ -270,7 +270,7 @@ contract InvestorActions is DestructibleModified {
     constant
     returns (uint ethAmount)
   {
-    return usdToEth(_shares.mul(fund.navPerShare()).div(10000));
+    return usdToEth(_shares.mul(fund.navPerShare()).div(10 ** fund.decimals()));
   }
 
   function usdToEth(uint _usd) 

--- a/contracts/NavCalculator.sol
+++ b/contracts/NavCalculator.sol
@@ -46,6 +46,7 @@ contract NavCalculator is DestructibleModified {
     uint grossAssetValue,
     uint netAssetValue,
     uint totalSupply,
+    uint adminFeeInPeriod,
     uint mgmtFeeInPeriod,
     uint performFeeInPeriod,
     uint lossPaybackInPeriod
@@ -110,7 +111,7 @@ contract NavCalculator is DestructibleModified {
       lossCarryforward = lossCarryforward.add(uint(-1 * netGainLossAfterPerformFee));
     }
 
-    LogNavCalculation(lastCalcDate, elapsedTime, grossAssetValue, netAssetValue, fund.totalSupply(), mgmtFee, performFee, lossPayback);
+    LogNavCalculation(lastCalcDate, elapsedTime, grossAssetValue, netAssetValue, fund.totalSupply(), adminFee, mgmtFee, performFee, lossPayback);
 
     return (lastCalcDate, navPerShare, lossCarryforward, accumulatedMgmtFees, accumulatedAdminFees);
   }
@@ -147,7 +148,7 @@ contract NavCalculator is DestructibleModified {
     constant 
     returns (uint performFee)  
   {
-    return fund.performFeeBps().mul(_usdGain).div(10000);
+    return fund.performFeeBps().mul(_usdGain).div(10 ** fund.decimals());
   }
 
   // Converts shares to a corresponding amount of USD based on the current nav per share
@@ -156,7 +157,7 @@ contract NavCalculator is DestructibleModified {
     constant 
     returns (uint usd) 
   {
-    return _shares.mul(fund.navPerShare()).div(10000);
+    return _shares.mul(fund.navPerShare()).div(10 ** fund.decimals());
   }
 
   function ethToUsd(uint _eth) 
@@ -172,6 +173,6 @@ contract NavCalculator is DestructibleModified {
     internal 
     constant 
     returns (uint) {
-    return _balance.mul(10000).div(fund.totalSupply());
+    return _balance.mul(10 ** fund.decimals()).div(fund.totalSupply());
   }
 }

--- a/js/Fund-test.js
+++ b/js/Fund-test.js
@@ -9,13 +9,14 @@ getBal = address => web3.fromWei(web3.eth.getBalance(address), 'ether').toNumber
 weiToNum = wei => web3.fromWei(wei, 'ether').toNumber()
 ethToWei = eth => web3.toWei(eth, 'ether')
 
-manager = web3.eth.accounts[0]
+owner = web3.eth.accounts[0]
 exchange = web3.eth.accounts[1]
 investor1 = web3.eth.accounts[2]
 investor2 = web3.eth.accounts[3]
+manager = web3.eth.accounts[4]
 
 // (IF TESTNET) Unlock accounts
-web3.personal.unlockAccount(manager, '<INSERT PASSWORD>', 15000)
+web3.personal.unlockAccount(owner, '<INSERT PASSWORD>', 15000)
 web3.personal.unlockAccount(exchange, '<INSERT PASSWORD>', 15000)
 web3.personal.unlockAccount(investor1, '<INSERT PASSWORD>', 15000)
 web3.personal.unlockAccount(investor2, '<INSERT PASSWORD>', 15000)
@@ -69,10 +70,6 @@ fund.approve(investor2, ethToWei(1), {from:investor1});
 
 // investor2 pulls one token from investor1
 fund.transferFrom(investor1, investor2, ethToWei(1), {from:investor2});
-
-// Remit fees from exchange to contract
-fund.getTotalFees().then(amount => fund.remitFromExchange({from:exchange, value:amount, gas:gasAmt}))
-fund.withdrawFees()
 
 // Investor requests redemption
 fund.requestRedemption(6000,{from:investor2})

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -21,7 +21,8 @@ const MANAGER_INVESTMENT            = 0;
 const MIN_INITIAL_SUBSCRIPTION_ETH  = 20;
 const MIN_SUBSCRIPTION_ETH          = 5;
 const MIN_REDEMPTION_SHARES         = 1000;
-const MGMT_FEE                      = 1;
+const ADMIN_FEE                     = 1;
+const MGMT_FEE                      = 0;
 const PERFORM_FEE                   = 20;
 
 module.exports = function(deployer, network, accounts) {
@@ -37,6 +38,7 @@ module.exports = function(deployer, network, accounts) {
     navServiceUrl,                    // _queryUrl
     SECONDS_BETWEEN_QUERIES,          // _secondsBetweenQueries
     USD_ETH_EXCHANGE_RATE * 100,      // _initialExchangeRate
+    accounts[0],                      // _manager
     accounts[1],                      // _exchange
     {from: accounts[0], value: dataFeedReserve}
   ).then(() =>

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -18,6 +18,7 @@ const FUND_NAME                     = "CoinAlpha Falcon";
 const FUND_SYMBOL                   = "FALC";
 const FUND_DECIMALS                 = 4;
 const MANAGER_INVESTMENT            = 0;
+const MANAGER_USD_ETH_BASIS         = 300;
 const MIN_INITIAL_SUBSCRIPTION_ETH  = 20;
 const MIN_SUBSCRIPTION_ETH          = 5;
 const MIN_REDEMPTION_SHARES         = 1000;
@@ -64,6 +65,7 @@ module.exports = function(deployer, network, accounts) {
       MIN_REDEMPTION_SHARES,          // _minRedemptionShares,
       MGMT_FEE * 100,                 // _mgmtFeeBps
       PERFORM_FEE * 100,              // _performFeeBps
+      MANAGER_USD_ETH_BASIS * 100,    // _managerUsdEthBasis
       {from: accounts[0], value: MANAGER_INVESTMENT}
   ));
 };

--- a/test/0_ownable.js
+++ b/test/0_ownable.js
@@ -5,28 +5,33 @@ const allArtifacts = {
   OwnableModified: artifacts.require('./OwnableModified.sol'),
   Fund: artifacts.require('./Fund.sol'),
   NavCalculator: artifacts.require('./NavCalculator.sol'),
-  InvestorActions: artifacts.require('./InvestorActions.sol')
+  InvestorActions: artifacts.require('./InvestorActions.sol'),
+  DataFeed: artifacts.require('./DataFeed.sol'),
 };
 
 const constructors = {
   OwnableModified: owner => allArtifacts.OwnableModified.new({ from: owner }),
-  Fund: (owner, exchange, navCalculator, investorActions) =>
+  Fund: (owner, exchange, navCalculator, investorActions, dataFeed) =>
     allArtifacts.OwnableModified.new(
+      owner,                    // _manager
       exchange,                 // _exchange
       navCalculator,            // _navCalculator
-      investorActions,          // investorActions
+      investorActions,          // _investorActions
+      dataFeed,                 // _dataFeed
       'FundName',               // _name
       'SYMB',                   // _symbol
       4,                        // _decimals
       20e18,                    // _minInitialSubscriptionEth
       5e18,                     // _minSubscriptionEth
-      5e18,                     // _minRedemptionShares,
+      5000,                     // _minRedemptionShares,
+      100,                      // _adminFeeBps
       100,                      // _mgmtFeeBps
       0,                        // _performFeeBps
+      30000,                    // _managerUsdEthBasis
       { from: owner }
     ),
   NavCalculator: (owner, dataFeed) => allArtifacts.NavCalculator.new(dataFeed, { from: owner }),
-  InvestorActions: owner => allArtifacts.InvestorActions.new({ from: owner })
+  InvestorActions: (owner, dataFeed) => allArtifacts.InvestorActions.new(dataFeed, { from: owner })
 };
 
 contract('OwnableModified', (accounts) => {


### PR DESCRIPTION
This PR addresses the changes we discussed with Orrick on the call yesterday:
* Separates administrator role from the manager.  Administrator earns an admin fee which is also calculated as a % of `totalSupply`.  Admin fee = 1, Mgmt fee = 0.
* Removes ERC20 `transfer` and `transferFrom` functionality
* Removes the `balances` mapping since the token is no longer ERC20 and it is redundant with `getInvestor.sharesOwned`
* Adds a required `usdEthBasis` field to `requestSubscription` to comply with tax requirements
* Uses the `decimals` variable to set the # of decimals for `navPerShare`
* Changes the fallback function so that it calls `remitFromExchange`, so that it can only be used by exchange address to remit Ether back to the fund contract