### PR TITLE
use nav service value to set manager investment

### DIFF
--- a/contracts/DataFeed.sol
+++ b/contracts/DataFeed.sol
@@ -52,14 +52,13 @@ contract DataFeed is usingOraclize, DestructibleModified {
     secondsBetweenQueries = _secondsBetweenQueries;
     exchange = _exchange;
     usdEth = _initialExchangeRate;
-    gasLimit = 300000;                                // Adjust this value depending on code length
+    gasLimit = 300000;              // Adjust this value depending on code length
+    gasPrice = 20000000000;         // 20 GWei, Oraclize default
 
     if (useOraclize) {
-      oraclize_setCustomGasPrice(20000000000 wei);    // 20 GWei, Oraclize default
+      oraclize_setCustomGasPrice(gasPrice);    
       oraclize_setProof(proofType_NONE);
       updateWithOraclize();
-    } else {
-      updateWithExchange(100);
     }
   }
 

--- a/js/Fund-test.js
+++ b/js/Fund-test.js
@@ -13,7 +13,7 @@ owner = web3.eth.accounts[0]
 exchange = web3.eth.accounts[1]
 investor1 = web3.eth.accounts[2]
 investor2 = web3.eth.accounts[3]
-manager = web3.eth.accounts[4]
+manager = web3.eth.accounts[0]
 
 // (IF TESTNET) Unlock accounts
 web3.personal.unlockAccount(owner, '<INSERT PASSWORD>', 15000)

--- a/migrations/config/datafeed-template.js
+++ b/migrations/config/datafeed-template.js
@@ -1,16 +1,12 @@
 // Create a file called datafeed.js duplicating this file and replace the values below
 
 module.exports = {
-  development: {
-    navServiceUrl: '[NOT USED]',
-  },
-  test: {
-    navServiceUrl: "[STAGING URL]"
-  },
   ropsten: {
     navServiceUrl: '[STAGING URL]',
+    dataFeedAddress: '',
   },
   mainnet: {
     navServiceUrl: '[PRODUCTION URL]',
+    dataFeedAddress: '',
   },
 };


### PR DESCRIPTION
This sets the manager investment to the portfolio value in the `nav-service`.

Also, it changes the deploy script when deploying to testnet or mainnet.  Deploy script assumes that the administrator has already deployed the DataFeed contract and the value() is available on it.

Builds off of prior PR.