### PR TITLE
remove helpers from modules

### DIFF
--- a/contracts/InvestorActions.sol
+++ b/contracts/InvestorActions.sol
@@ -58,7 +58,7 @@ contract InvestorActions is DestructibleModified {
   {
     var (ethTotalAllocation, ethPendingSubscription, sharesOwned, sharesPendingRedemption, ethPendingWithdrawal) = fund.getInvestor(_addr);
 
-    uint ethFilledAllocation = ethPendingSubscription.add(sharesToEth(sharesOwned));
+    uint ethFilledAllocation = ethPendingSubscription.add(fund.sharesToEth(sharesOwned));
 
     if (ethTotalAllocation > ethFilledAllocation) {
       return ethTotalAllocation.sub(ethFilledAllocation);
@@ -82,7 +82,7 @@ contract InvestorActions is DestructibleModified {
     } else {
       require(_amount >= fund.minSubscriptionEth());
     }
-    require(ethTotalAllocation >= _amount.add(ethPendingSubscription).add(sharesToEth(sharesOwned)));
+    require(ethTotalAllocation >= _amount.add(ethPendingSubscription).add(fund.sharesToEth(sharesOwned)));
 
     return (ethPendingSubscription.add(_amount),                                 // new investor.ethPendingSubscription
             fund.totalEthPendingSubscription().add(_amount)                      // new totalEthPendingSubscription
@@ -123,7 +123,7 @@ contract InvestorActions is DestructibleModified {
     // to the exchange account upon function return
     uint otherPendingSubscriptions = fund.totalEthPendingSubscription().sub(ethPendingSubscription);
     require(ethPendingSubscription <= fund.balance.sub(fund.totalEthPendingWithdrawal()).sub(otherPendingSubscriptions));
-    uint shares = ethToShares(ethPendingSubscription);
+    uint shares = fund.ethToShares(ethPendingSubscription);
 
     return (0,                                                                  // new investor.ethPendingSubscription
             sharesOwned.add(shares),                                            // new investor.sharesOwned
@@ -179,7 +179,7 @@ contract InvestorActions is DestructibleModified {
 
     // Check that the fund balance has enough ether because after this function is processed, the ether
     // equivalent amount can be withdrawn by the investor
-    uint amount = sharesToEth(sharesPendingRedemption);
+    uint amount = fund.sharesToEth(sharesPendingRedemption);
     require(amount <= fund.balance.sub(fund.totalEthPendingSubscription()).sub(fund.totalEthPendingWithdrawal()));
 
     return (sharesOwned.sub(sharesPendingRedemption),                           // new investor.sharesOwned
@@ -204,7 +204,7 @@ contract InvestorActions is DestructibleModified {
     // equivalent amount can be withdrawn by the investor.  The fund balance less total withdrawals and other
     // investors' pending subscriptions should be larger than or equal to the liquidated amount.
     uint otherPendingSubscriptions = fund.totalEthPendingSubscription().sub(ethPendingSubscription);
-    uint amount = sharesToEth(sharesOwned).add(ethPendingSubscription);
+    uint amount = fund.sharesToEth(sharesOwned).add(ethPendingSubscription);
     require(amount <= fund.balance.sub(fund.totalEthPendingWithdrawal()).sub(otherPendingSubscriptions));
 
     return (ethPendingWithdrawal.add(amount),                                   // new investor.ethPendingWithdrawal
@@ -249,43 +249,11 @@ contract InvestorActions is DestructibleModified {
   }
 
   // Update the address of the data feed contract
-  function setDataFeed(address _address) onlyOwner {
+  function setDataFeed(address _address) 
+    onlyOwner 
+    returns (bool success)
+  {
     dataFeed = DataFeed(_address);
-  }
-
-  // ********* HELPERS *********
-
-  // Converts ether to a corresponding number of shares based on the current nav per share
-  function ethToShares(uint _eth)
-    internal
-    constant
-    returns (uint shares)
-  {
-    return ethToUsd(_eth).mul(10 ** fund.decimals()).div(fund.navPerShare());
-  }
-
-  // Converts shares to a corresponding amount of ether based on the current nav per share
-  function sharesToEth(uint _shares)
-    internal
-    constant
-    returns (uint ethAmount)
-  {
-    return usdToEth(_shares.mul(fund.navPerShare()).div(10 ** fund.decimals()));
-  }
-
-  function usdToEth(uint _usd) 
-    internal
-    constant 
-    returns (uint eth) 
-  {
-    return _usd.mul(1e20).div(dataFeed.usdEth());
-  }
-
-  function ethToUsd(uint _eth) 
-    internal
-    constant 
-    returns (uint usd) 
-  {
-    return _eth.mul(dataFeed.usdEth()).div(1e20);
+    return true;
   }
 }

--- a/contracts/NavCalculator.sol
+++ b/contracts/NavCalculator.sol
@@ -71,7 +71,7 @@ contract NavCalculator is DestructibleModified {
     // The new grossAssetValue equals the updated value, denominated in ether, of the exchange account,
     // plus any amounts that sit in the fund contract, excluding unprocessed subscriptions
     // and unwithdrawn investor payments.
-    uint grossAssetValue = dataFeed.value().add(ethToUsd(fund.getBalance()));
+    uint grossAssetValue = dataFeed.value().add(fund.ethToUsd(fund.getBalance()));
 
     // Removes the accumulated management fees from grossAssetValue
     uint gpvLessFees = grossAssetValue.sub(fund.accumulatedMgmtFees()).sub(fund.accumulatedAdminFees());
@@ -164,14 +164,6 @@ contract NavCalculator is DestructibleModified {
     returns (uint usd) 
   {
     return _shares.mul(fund.navPerShare()).div(10 ** fund.decimals());
-  }
-
-  function ethToUsd(uint _eth) 
-    internal 
-    constant 
-    returns (uint usd) 
-  {
-    return _eth.mul(dataFeed.usdEth()).div(1e20);
   }
 
   // Converts total fund NAV to NAV per share

--- a/test/2_nav_calculator.js
+++ b/test/2_nav_calculator.js
@@ -49,8 +49,6 @@ contract('NavCalculator', (accounts) => {
 
   const checkRoughEqual = (vals, navPerShare, lossCarryforward, accumulatedMgmtFees, accumulatedAdminFees) => {
     [ansNAV, ansLCF, ansAMF, ansAPF] = vals;
-    // console.log('navPerShare', parseInt(navPerShare));
-    // console.log('ansNAV', ansNAV);
     assert(Math.abs(parseInt(navPerShare) / ansNAV - 1) < 0.0001, 'incorrect navPerShare');
 
     if (ansLCF !== 0) assert(Math.abs(parseInt(lossCarryforward) / ansLCF - 1) < 0.0001, 'incorrect lossCarryforward');
@@ -58,9 +56,6 @@ contract('NavCalculator', (accounts) => {
 
     if (ansAMF !== 0) assert(Math.abs(parseInt(accumulatedMgmtFees) / ansAMF - 1) < 0.0001, 'incorrect accumulatedMgmtFees');
     else assert.equal(parseInt(accumulatedMgmtFees), 0, 'incorrect accumulatedMgmtFees');
-
-    console.log(parseInt(accumulatedAdminFees));
-    console.log(ansAPF);
 
     if (ansAPF !== 0) assert(Math.abs(parseInt(accumulatedAdminFees) / ansAPF - 1) < 0.0001, 'incorrect accumulatedAdminFees');
     else assert.equal(parseInt(accumulatedAdminFees), 0, 'incorrect accumulatedAdminFees');
@@ -156,7 +151,8 @@ contract('NavCalculator', (accounts) => {
   it('should calculate the navPerShare correctly (base case)', (done) => {
     let date1, date2, navPerShare, lossCarryforward, accumulatedMgmtFees, accumulatedAdminFees;
 
-    fund.lastCalcDate.call()
+    Promise.resolve(changeExchangeValue(100))
+      .then(() => fund.lastCalcDate.call())
       .then(_date => date1 = _date)
       .then(() => Promise.resolve(increaseTime(TIMEDIFF)))
       .then(() => fund.calcNav())


### PR DESCRIPTION
Instead of defining helpers in the submodules, just use the ones in main contract